### PR TITLE
Add OpenStack auth as parameters instead of env vars

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -1,6 +1,8 @@
 ---
 
 cluster_state: present
+cluster_auth_type:
+cluster_auth:
 cluster_environment:
   - "{{ role_path }}/files/environment.yaml"
 cluster_template: "{{ role_path }}/files/resources/cluster.yaml"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,8 @@
 - name: Create or update cluster Heat stack
   os_stack:
     name: "{{ cluster_name }}"
+    auth_type: "{{ cluster_auth_type or omit }}"
+    auth: "{{ cluster_auth or omit }}"
     state: "{{ cluster_state }}"
     environment: "{{ cluster_environment }}"
     template: "{{ cluster_template }}"


### PR DESCRIPTION
It appears when running from the command line we were drawing in our OpenStack authentication credentials from the shell environment, rather than group_vars.  When we move to passing in authentication via token we'll probably need to control this more closely.