### PR TITLE
Return cluster group info as output after string replacement

### DIFF
--- a/files/resources/cluster.yaml
+++ b/files/resources/cluster.yaml
@@ -70,3 +70,6 @@ outputs:
 
   deploy_private_key:
     value: { get_attr: [deploy_keypair, private_key] }
+
+  info:
+    value: { get_attr: [node_groups, group_data, info] }

--- a/files/resources/group.yaml
+++ b/files/resources/group.yaml
@@ -83,3 +83,8 @@ outputs:
     value:
       name: { get_param: [cluster_groups, { get_param: group_idx }, name] }
       nodes: { get_attr: [node_group, instance_data] }
+      info:
+        str_replace:
+          template: { get_param: [cluster_groups, { get_param: group_idx }, info] }
+          params:
+            "\"$PRIMARY_IPS\"": { get_attr: [port_group, primary_ip] }


### PR DESCRIPTION
Each cluster group can include an `info` key, whose value is expected to
be a JSON object encoded as a string. We substitute "$PRIMARY_IPS" in
the JSON object by the list of primary IPs allocated to this group, and
return it as another key of the `group_data` output value.

In the cluster template, info from each group is put together in an
`info` output value, resulting in a list of JSON objects.