### PR TITLE
Add a gateway group to the inventory first

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,6 +21,7 @@
       set_fact:
         cluster_gw_user: "{{ cluster_parameters.cluster_groups | selectattr('name', 'equalto', cluster_gw_group) | map(attribute='user') | first }}"
         cluster_gw_ip: "{{ (cluster_node_groups | selectattr('name', 'equalto', cluster_gw_group) | first).nodes | map(attribute='ip') | first }}"
+        cluster_node_group_gw: "{{ cluster_node_groups | selectattr('name', 'equalto', cluster_gw_group) | list }}"
       when:
         - cluster_gw_group is defined
         - cluster_gw_user is not defined or cluster_gw_ip is not defined
@@ -34,6 +35,15 @@
         content: "{{ cluster_private_key }}"
         dest: "{{ cluster_private_key_file }}"
         mode: 0600
+
+    - name: Build in-memory inventory for gateway group/host
+      include_tasks: add_inventory_group.yml
+      with_items: "{{ cluster_node_group_gw }}"
+      loop_control:
+        loop_var: group
+      when:
+        - cluster_gw_group is defined
+        - cluster_gw_host is not defined
 
     - name: Build in-memory inventory
       include_tasks: add_inventory_group.yml


### PR DESCRIPTION
This prevents a gateway group appended to the stack list
from being referred to prematurely.